### PR TITLE
#166840911 Setting up coveralls services using coveralls.io

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: COVERALLS_REPO_TOKEN

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+## Badges
 [![Build Status](https://travis-ci.com/andela/ah-kifaru-backend.svg?branch=develop)](https://travis-ci.com/andela/ah-kifaru-backend)
-`## Badges
+[![Coverage Status](https://coveralls.io/repos/github/andela/ah-kifaru-backend/badge.svg?branch=ch-integrate-coveralls-code-climate-services-166840911)](https://coveralls.io/github/andela/ah-kifaru-backend?branch=ch-integrate-coveralls-code-climate-services-166840911)
 [![](https://img.shields.io/badge/Reviewed%20by-Hound-brightgreen.svg)](https://houndci.com)`
 
 =======

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
     "description": "A Social platform for the creative at heart",
     "main": "index.js",
     "scripts": {
-        "test": "mocha --require @babel/register --require @babel/polyfill src/test --exit",
+        "test": "nyc mocha --require @babel/register --require @babel/polyfill src/test --exit",
         "lint": "eslint **/*.js",
         "lint:fix": "prettier-eslint \"**/*.{js,json}\" --write",
         "prettier": "prettier **/*.{js,json} --write",
         "start": "",
-        "start:dev": "nodemon --exec babel-node src/index"
+        "start:dev": "nodemon --exec babel-node src/index",
+        "coverage": "nyc report --reporter=text-lcov | coveralls"
     },
     "husky": {
         "hooks": {
@@ -63,6 +64,7 @@
         "@babel/register": "^7.4.4",
         "chai": "^4.2.0",
         "chai-http": "^4.3.0",
+        "coveralls": "^3.0.4",
         "eslint": "^5.16.0",
         "eslint-config-airbnb-base": "^13.1.0",
         "eslint-config-prettier": "^5.1.0",
@@ -71,6 +73,7 @@
         "husky": "^2.5.0",
         "mocha": "^6.1.4",
         "nodemon": "^1.19.1",
+        "nyc": "^14.1.1",
         "prettier": "^1.18.2",
         "prettier-eslint": "^9.0.0",
         "prettier-eslint-cli": "^5.0.0"


### PR DESCRIPTION
### What does this PR do?
This PR sets coverage services using coveralls.io in the project.

### Description of Task to be completed?
- fixed the issue of Hound CI badge
- installed NYC and coveralls as dev dependencies
- created a .coveralls.yml file and added a repo_token to it
- created a coverage script and added the command for the script to run after_success by Travis

### How should this be manually tested?
- **_npm test_**  to run the test
- **_npm run coverage_** to estimate coverage
N.B The repo token for coveralls was placed online as an environment variables for security reasons

### Any background context you want to provide?
N/A

### What are the relevant pivotal tracker stories?
#166840911

Screenshots (if appropriate)
<img width="507" alt="Screenshot 2019-06-30 at 11 29 45 PM" src="https://user-images.githubusercontent.com/46568513/60402986-064f4e00-9b8f-11e9-9d69-82b5ea6670d6.png">
